### PR TITLE
Praha CZNIC: 12. data misto asteriodu, 13. asteroidy misto zavercne hodiny

### DIFF
--- a/runs/2018/pyladies-praha-podzim-cznic/info.yml
+++ b/runs/2018/pyladies-praha-podzim-cznic/info.yml
@@ -115,15 +115,16 @@ plan:
   date: 2018-11-13
 - base: class
   date: 2018-11-20
-- base: asteroids
-  date: 2018-11-27
   materials:
   - title: Turnaj v piškvorkách
     url: null
     type: special
   - +merge
-- title: Závěrečná procvičovací hodina
-  slug: final
+- slug: data
+  title: Data
+  date: 2018-11-27
+  materials:
+  - lesson: intro/notebook
+  - lesson: intro/pandas
+- base: asteroids
   date: 2018-12-04
-  description: Během závěrečné hodiny se mimojiné seznámíme s možnostmi dalšího vzdělávání
-  materials: []


### PR DESCRIPTION
Rikala mi dnes o to asi Radka P.

Zmena je pouze v CZ.NICu (Olsanka), nevim, jestli ma byt i jinde.

Nevim, kdy ma byt piskvorkovy turnaj, tak jsem ho nechal posledni hodinu.

Screenshot before - after:

![image](https://user-images.githubusercontent.com/115487/46907567-cbc85700-cf14-11e8-81fd-f8eddf57f3a7.png)
