### PR TITLE
Založ nový běh pro ostravské jaro 2019

### DIFF
--- a/runs/2019/pyladies-ostrava-jaro/info.yml
+++ b/runs/2019/pyladies-ostrava-jaro/info.yml
@@ -1,0 +1,271 @@
+title: Začátečnický kurz PyLadies
+subtitle: Ostrava – jaro 2019
+time: 17:00–19:00
+default_time:
+  start: '17:00'
+  end: '19:00'
+place: Tieto Towers, 28. října 3346/91, Moravská Ostrava, Ostrava
+description: Naučte se Python vážně od začátku. Žádné předchozí znalosti nejsou potřeba.
+long_description: |
+    Tady najdeš všechny materiály k ostravské verzi začátečnického kurzu
+    PyLadies.
+
+    Stránky samotných PyLadies jsou na [http://pyladies.cz][PyLadies].
+
+    Jednotlivé lekce jsou určeny naprostým začátečnicím.
+    Instrukce jsou uvedeny pro operační systémy Linux, Windows i macOS.
+
+    [PyLadies]: https://pyladies.cz/
+derives: pyladies
+vars:
+  user-gender: f
+  pyladies: true
+  coach-present: true
+plan:
+- title: Instalace
+  slug: install
+  date: 2019-02-05
+  materials:
+    - url: http://pyladies.cz/v1/s001-install/uvod-ostrava.html
+      title: Úvodní prezentace
+    - lesson: beginners/cmdline
+      type: lesson
+    - lesson: beginners/install
+      type: lesson
+    - lesson: beginners/first-steps
+      type: lesson
+    - lesson: beginners/install-editor
+      type: lesson
+    - title: Tahák na klávesnici (PDF)
+      url: https://pyvec.github.io/cheatsheets/keyboard/keyboard-cs.pdf
+      type: cheatsheet
+    - title: Instrukce a domácí projekty (PDF)
+      url: http://pyladies.cz/v1/s001-install/handout/handout.pdf
+      type: homework
+- title: První program
+  slug: hello-world
+  date: 2019-02-12
+  materials:
+    - lesson: beginners/hello-world
+      type: lesson
+    - lesson: beginners/print
+      title: Chybové hlášky a print
+      type: lesson
+    - lesson: beginners/variables
+      type: lesson
+    - lesson: beginners/comparisons
+      type: lesson
+    - title: Společná večeře PyLadies ve Slezské P.U.O.R.
+      type: special
+      url: http://slezska.com/
+    - title: Domácí projekty (PDF)
+      url: http://pyladies.cz/v1/s002-hello-world/handout/handout2-ostrava.pdf
+      type: homework
+    - title: "Nebo anebo a (bonus)"
+      lesson: beginners/and-or
+      vars:
+        bonus: true
+    - title: Odevzdání domácích projektů
+      type: link
+      url: https://www.dropbox.com/request/AACCcUMFnjUBKeMCXzms
+- title: Cykly
+  slug: loops
+  date: 2019-02-19
+  materials:
+    - lesson: beginners/functions
+      type: lesson
+    - lesson: intro/turtle
+      type: lesson
+    - title: Tahák s užitečnými funkcemi
+      url: https://pyvec.github.io/cheatsheets/basic-functions/basic-functions-cs.pdf
+      type: cheatsheet
+    - title: Domácí projekty (PDF)
+      url: http://pyladies.cz/v1/s003-looping/handout/handout3a.pdf
+      type: homework
+    - title: Odevzdání domácích projektů
+      type: link
+      url: https://www.dropbox.com/request/1C7qR4cK9s0gfEHP2rDI
+- title: Jeden nový cyklus a procvičování
+  slug: while
+  date: 2019-02-26
+  materials:
+    - lesson: beginners/while
+      type: lesson
+    - title: Úkoly k procvičování
+      type: link
+      url: http://pyladies.cz/v1/s003-looping/ostrava/ukoly-k-procvicovani/ukoly.html
+    - title: Domácí projekty (PDF)
+      type: homework
+      url: http://pyladies.cz/v1/s003-looping/handout/handout3b-ostrava.pdf
+    - title: Odevzdání domácích projektů
+      type: link
+      url: https://www.dropbox.com/request/b0l0jiJhNNUBhdf0ncl5
+- title: Funkce a řetězce
+  slug: def-str
+  date: 2019-03-05
+  materials:
+    - lesson: beginners/def
+      type: lesson
+    - lesson: beginners/str
+      type: lesson
+    - title: Řetězcový tahák
+      url: https://pyvec.github.io/cheatsheets/strings/strings-cs.pdf
+      type: cheatsheet
+    - title: Domácí projekty (PDF)
+      url: http://pyladies.cz/v1/s004-strings/handout/handout4-ostrava.pdf
+      type: homework
+    - title: Odevzdání domácích projektů
+      type: link
+      url: https://www.dropbox.com/request/ztWlVnOsOM1smoLPxltm
+- title: Soubory a výjimky
+  slug: file
+  date: 2019-03-12
+  materials:
+    - lesson: beginners/exceptions
+      type: lesson
+    - lesson: beginners/files
+      type: lesson
+    - title: Domácí projekty A (PDF)
+      type: homework
+      url: http://pyladies.cz/v1/s005-modules/handout/handout5a-ostrava.pdf
+    - title: Domácí projekty B (PDF)
+      type: homework
+      url: http://pyladies.cz/v1/s005-modules/handout/handout7-ostrava.pdf
+    - title: odkaz k domácím projektům – hiragana
+      url: http://pyladies.cz/v1/s006-lists/resources/hiragana.txt
+      type: link
+    - title: odkaz k domácím projektům – katakana
+      url: http://pyladies.cz/v1/s006-lists/resources/katakana.txt
+      type: link
+    - title: odkaz k domácím projektům – „日本語の表記体系” na japonské Wikipedii
+      url: http://ja.wikipedia.org/wiki/%E6%97%A5%E6%9C%AC%E8%AA%9E%E3%81%AE%E8%A1%A8%E8%A8%98%E4%BD%93%E7%B3%BB
+      type: link
+    - title: Odevzdání domácích projektů
+      type: link
+      url: https://www.dropbox.com/request/BLnJ6NvNedROu9HkB1rw
+- title: Seznamy
+  slug: list
+  date: 2019-03-19
+  materials:
+    - lesson: beginners/list
+      type: lesson
+    - lesson: beginners/tuple
+      type: lesson
+    - title: Tahák na seznamy
+      url: https://pyvec.github.io/cheatsheets/lists/lists-cs.pdf
+      type: cheatsheet
+    - title: Domácí projekty (PDF)
+      url: http://pyladies.cz/v1/s006-lists/handout-ostrava/handout6.pdf
+      type: homework
+    - title: Odevzdání domácích projektů
+      type: link
+      url: https://www.dropbox.com/request/U1mnwyGK9KimfVummSEZ
+- title: Slovníky
+  slug: dict
+  date: 2019-03-26
+  materials:
+    - lesson: beginners/dict
+      type: lesson
+    - lesson: intro/json
+      type: lesson
+    - title: Ukázka jednoduchého API
+      type: lesson
+      url: http://pyladies.cz/v1/s011-dicts/simple-api.html
+    - title: Slovníkový tahák
+      url: https://pyvec.github.io/cheatsheets/dicts/dicts-cs.pdf
+      type: cheatsheet
+    - title: Domácí projekty (PDF)
+      type: homework
+      url: https://pyladies.cz/v1/s011-dicts/handout/handout9.pdf
+    - title: Odevzdání domácích projektů
+      type: link
+      url: https://www.dropbox.com/request/oJ3pgen7AmDea0lBfPog
+- title: Moduly a testování
+  slug: modules-testing
+  date: 2019-04-02
+  materials:
+    - lesson: beginners/modules
+      type: lesson
+    - lesson: beginners/circular-imports
+      title: Poznámka o importování
+      type: lesson
+    - title: Domácí projekty k modulům (PDF)
+      url: http://pyladies.cz/v1/s005-modules/handout/handout5b-ostrava.pdf
+      type: homework
+    - lesson: beginners/testing
+      type: lesson
+    - title: Domácí projekty k testování (PDF)
+      type: homework
+      url: http://pyladies.cz/v1/s005-modules/handout/handout5c-ostrava.pdf
+    - title: Odevzdání domácích projektů
+      type: link
+      url: https://www.dropbox.com/request/xApsz9zKYxknLpJf8Qml
+- title: Grafika
+  slug: pyglet
+  date: 2019-04-09
+  materials:
+    - lesson: intro/pyglet
+      type: lesson
+    - title: "Praktické cvičení: Pong – mimo kurz navíc"
+      lesson: projects/pong
+    - title: Kód celé hry Pong
+      url:  http://pyladies.cz/v1/s012-pyglet/pong.py
+    - title: Tahák na Pyglet
+      url: https://pyvec.github.io/cheatsheets/pyglet/pyglet-basics-cs.pdf
+      type: cheatsheet
+    - title: Domácí projekty (PDF)
+      type: homework
+      url: https://pyladies.cz/v1/s012-pyglet/handout/handout.pdf
+    - title: Odevzdání domácích projektů
+      type: link
+      url: https://www.dropbox.com/request/3e5TNn6NBlfI7SD5GFrW
+- title: Třídy
+  slug: class
+  date: 2019-04-16
+  materials:
+    - lesson: beginners/class
+      type: lesson
+    - lesson: beginners/inheritance
+      type: lesson
+    - title: Domácí projekty (PDF)
+      type: homework
+      url: https://pyladies.cz/v1/s014-class/handout/handout.pdf
+    - title: Odevzdání domácích projektů
+      type: link
+      url: https://www.dropbox.com/request/SOtp5ITHEPscn0MqzEM5
+- title: Dědičnost
+  slug: inheritance
+  date: 2019-04-23
+  materials:
+    - lesson: beginners/inheritance
+      type: lesson
+    - title: Domácí projekty (PDF)
+      type: homework
+      url: https://pyladies.cz/v1/s014-class/handout/handout.pdf
+    - title: Odevzdání domácích projektů
+      type: link
+      url: https://www.dropbox.com/request/AqCwMoyF9FuyI6Sinwu0
+- title: Závěrečný projekt
+  slug: asteroids
+  date: 2019-04-30
+  materials:
+    - lesson: projects/asteroids
+      type: lesson
+    - lesson: projects/snake
+      type: lesson
+    - title: Množinový tahák
+      url: https://pyvec.github.io/cheatsheets/sets/sets-cs.pdf
+      type: cheatsheet
+    - title: Tahák na geometrii a fyziku 2D her
+      url: https://pyvec.github.io/cheatsheets/game-physics/game-physics-cs.pdf
+      type: cheatsheet
+- title: Pokračování závěrečného projektu
+  slug: asteroids2
+  date: 2019-05-07
+  description: V této lekci budeme pokračovat v dalších fázích závěrečného projektu.
+  materials: []
+- title: Závěrečná hodina
+  slug: asteroids3
+  date: 2019-05-14
+  description: Během závěrečné hodiny si předáme diplomy a seznámíme se s možnostmi pokračování studia
+  materials: []


### PR DESCRIPTION
Vytvořen nový běh pro jarní Ostravu v roce 2019. Zkopírován podzimní z roku 2018 a upraveny datumy. Sloučeny moduly s testováním, rozděleny třídy a dědičnost. Upravena typografie. Vyměněny odkazy na odevzdání domácích projektů.