### PR TITLE
Fix typo in Prague courses

### DIFF
--- a/runs/2019/pyladies-praha-jaro-ntk/info.yml
+++ b/runs/2019/pyladies-praha-jaro-ntk/info.yml
@@ -56,7 +56,7 @@ plan:
       bonus: true
 - base: loops
   date: 2019-03-21
-  materils:
+  materials:
     - lesson: beginners/functions
       type: lesson
     - lesson: intro/turtle


### PR DESCRIPTION
The typo makes lesson `beginners/while` appear in two sessions simultaneously - it probably uses some default content from somewhere else:

```
$ curl -sS https://naucse.python.cz/v0/2019/pyladies-praha-jaro-ntk.json | jq '.course.sessions[]' | jq -c '[ .slug, [ .materials[].lesson_slug ]]' | grep while
["loops",["beginners/functions","intro/turtle","beginners/while",null]]
["while-functions",["beginners/while","beginners/def"]]
```