### PR TITLE
Deduplicate lesson slug

### DIFF
--- a/runs/2020/pyladies-praha-jaro-cznic/info.yml
+++ b/runs/2020/pyladies-praha-jaro-cznic/info.yml
@@ -69,7 +69,7 @@ plan:
   materials:
     - lesson: beginners/while
       type: lesson
-- slug: while-functions
+- slug: def
   title: Vlastní funkce
   date: 2020-03-31
   materials:


### PR DESCRIPTION
The slug is used in the URL, so it must be unique for each lesson.